### PR TITLE
Fixes for additional flexibility in builds on Ubuntu

### DIFF
--- a/messenger-client/Makefile
+++ b/messenger-client/Makefile
@@ -1,3 +1,3 @@
 install:
 	pip uninstall -y messenger
-	python setup.py install
+	which python || python3 setup.py install && python setup.py install

--- a/messenger-server/CMakeLists.txt
+++ b/messenger-server/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.17)
+cmake_minimum_required(VERSION 3.16)
 project(messenger_server)
 
 set(CMAKE_CXX_STANDARD 14)


### PR DESCRIPTION
Lower cmake_minimum_version to 3.16 cmake found some Ubuntu LTS `apt` repositories and add messenger-client makefile logic to use "python3" if "python" is not found on path.